### PR TITLE
Version 4.1.0

### DIFF
--- a/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXConfig.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXConfig.kt
@@ -12,6 +12,7 @@ import com.rommansabbir.networkx.exceptions.NetworkXNotInitializedException
  * @param application, [Application] reference to initialize NetworkX properly
  * @param enableSpeedMeter, determine if to enable monitoring network speed
  */
+@Deprecated("Use new SmartConfig.")
 class NetworkXConfig private constructor(
     val application: Application,
     val enableSpeedMeter: Boolean

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXLifecycle.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXLifecycle.kt
@@ -1,0 +1,9 @@
+package com.rommansabbir.networkx
+
+/**
+ * Define the lifecycle for NetworkX. Either activity or application.
+ */
+sealed class NetworkXLifecycle {
+    object Application : NetworkXLifecycle()
+    object Activity : NetworkXLifecycle()
+}

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXProvider.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/NetworkXProvider.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.rommansabbir.networkx.extension.getDefaultIOScope
 import com.rommansabbir.networkx.extension.getDefaultLastKnownSpeed
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
@@ -106,7 +105,13 @@ object NetworkXProvider {
             if (manager != null) {
                 return
             }
-            manager = NetworkXManager(application, enableSpeedMeter)
+            manager = NetworkXManager(
+                SmartConfig(
+                    application,
+                    enableSpeedMeter,
+                    NetworkXLifecycle.Application
+                )
+            )
         } catch (e: Exception) {
             throw e
         }
@@ -119,12 +124,46 @@ object NetworkXProvider {
      *
      * @param config [NetworkXConfig] reference.
      */
+    @Deprecated(
+        "Use new SmartConfig.",
+        replaceWith = ReplaceWith(
+            "NetworkXProvider.enable(SmartConfig(application, true, NetworkXLifecycle.Application))",
+            imports = arrayOf(
+                "com.rommansabbir.networkx.SmartConfig",
+                "com.rommansabbir.networkx.NetworkXLifecycle"
+            )
+        )
+    )
     fun enable(config: NetworkXConfig) {
         try {
             if (manager != null) {
                 return
             }
-            manager = NetworkXManager(config.application, config.enableSpeedMeter)
+            manager = NetworkXManager(
+                SmartConfig(
+                    config.application,
+                    config.enableSpeedMeter,
+                    NetworkXLifecycle.Application
+                )
+            )
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    /**
+     * Main entry point for the client.
+     * First check for [NetworkXManager] instance, if the status is null then initialize it properly
+     * else ignore the initialization.
+     *
+     * @param config [SmartConfig] reference.
+     */
+    fun enable(config: SmartConfig) {
+        try {
+            if (manager != null) {
+                return
+            }
+            manager = NetworkXManager(config)
         } catch (e: Exception) {
             throw e
         }

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/SmartConfig.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/SmartConfig.kt
@@ -1,0 +1,9 @@
+package com.rommansabbir.networkx
+
+import android.app.Application
+
+data class SmartConfig(
+    val application: Application,
+    val enableSpeedMeter: Boolean,
+    val lifecycle: NetworkXLifecycle
+)

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/dialog/NoInternetDialogV2.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/dialog/NoInternetDialogV2.kt
@@ -2,6 +2,8 @@ package com.rommansabbir.networkx.dialog
 
 import android.app.Activity
 import android.app.Dialog
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
 import com.rommansabbir.networkx.R
 import com.rommansabbir.networkx.databinding.ContentDialogNoInternetBinding
 import com.rommansabbir.networkx.extension.getDialogInstance
@@ -13,12 +15,13 @@ class NoInternetDialogV2 constructor(
     private val message: String,
     private val buttonTitle: String,
     private val isCancelable: Boolean,
+    @DrawableRes private val drawable: Int? = null,
     private val callback: () -> Unit
 ) {
     init {
-        activity.get()?.let {
+        activity.get()?.let { activity ->
             getDialogInstance<ContentDialogNoInternetBinding>(
-                it,
+                activity,
                 R.layout.content_dialog_no_internet,
                 R.style.my_dialog,
                 isCancelable
@@ -27,6 +30,14 @@ class NoInternetDialogV2 constructor(
                 binding.cdniBtnRetry.text = buttonTitle
                 binding.cdniTvTitle.text = title
                 binding.cdniTvMessage.text = message
+                drawable?.let {
+                    binding.imageView.setImageDrawable(
+                        ContextCompat.getDrawable(
+                            activity,
+                            drawable
+                        )
+                    )
+                }
                 NoInternetDialogV2.dialog?.setOnDismissListener {
                     NoInternetDialogV2.dialog = null
                 }

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/dialog/NoInternetDialogV2.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/dialog/NoInternetDialogV2.kt
@@ -20,13 +20,12 @@ class NoInternetDialogV2 constructor(
 ) {
     init {
         activity.get()?.let { activity ->
-            getDialogInstance<ContentDialogNoInternetBinding>(
+            dialog = getDialogInstance<ContentDialogNoInternetBinding>(
                 activity,
                 R.layout.content_dialog_no_internet,
                 R.style.my_dialog,
                 isCancelable
-            ) { dialog, binding ->
-                NoInternetDialogV2.dialog = dialog
+            ) { binding ->
                 binding.cdniBtnRetry.text = buttonTitle
                 binding.cdniTvTitle.text = title
                 binding.cdniTvMessage.text = message
@@ -38,17 +37,27 @@ class NoInternetDialogV2 constructor(
                         )
                     )
                 }
-                NoInternetDialogV2.dialog?.setOnDismissListener {
-                    NoInternetDialogV2.dialog = null
-                }
-                binding.cdniBtnRetry.setOnClickListener { callback.invoke();NoInternetDialogV2.dialog?.cancel() }
-                NoInternetDialogV2.dialog?.show()
+
+                binding.cdniBtnRetry.setOnClickListener { callback.invoke(); forceClose() }
             }
+            dialog?.setOnDismissListener {
+                dialog = null
+            }
+            dialog?.show()
         } ?: kotlin.run { dialog = null }
     }
 
     companion object {
+        @Volatile
         private var dialog: Dialog? = null
+
         val isVisible: Boolean = dialog != null && dialog!!.isShowing
+        fun forceClose() {
+            try {
+                dialog?.cancel()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 }

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/exceptions/NoInternetDialogException.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/exceptions/NoInternetDialogException.kt
@@ -1,5 +1,0 @@
-package com.rommansabbir.networkx.exceptions
-
-class NoInternetDialogException :
-    Exception("Activity reference is required to build an instance of NoInternetDialog") {
-}

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/extension/NetworkXExtensions.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/extension/NetworkXExtensions.kt
@@ -1,10 +1,7 @@
 package com.rommansabbir.networkx.extension
 
 import androidx.lifecycle.LiveData
-import com.rommansabbir.networkx.LastKnownSpeed
-import com.rommansabbir.networkx.NetworkSpeedType
-import com.rommansabbir.networkx.NetworkXConfig
-import com.rommansabbir.networkx.NetworkXProvider
+import com.rommansabbir.networkx.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,4 +53,22 @@ internal val getDefaultIOScope by lazy { CoroutineScope(Dispatchers.IO) }
  *
  * @param config [NetworkXConfig].
  */
+
+@Deprecated(
+    "Use new extension API", replaceWith = ReplaceWith(
+        "smartEnableNetworkX(SmartConfig(application, true, NetworkXLifecycle.Application))",
+        imports = arrayOf(
+            "com.rommansabbir.networkx.extension.smartEnableNetworkX",
+            "com.rommansabbir.networkx.SmartConfig",
+            "com.rommansabbir.networkx.NetworkXLifecycle"
+        )
+    )
+)
 fun enableNetworkX(config: NetworkXConfig) = NetworkXProvider.enable(config)
+
+/**
+ * Initialize [NetworkXProvider].
+ *
+ * @param config [SmartConfig].
+ */
+fun smartEnableNetworkX(config: SmartConfig) = NetworkXProvider.enable(config)

--- a/NetworkX/src/main/java/com/rommansabbir/networkx/extension/ViewExtension.kt
+++ b/NetworkX/src/main/java/com/rommansabbir/networkx/extension/ViewExtension.kt
@@ -23,13 +23,14 @@ inline fun <V : ViewDataBinding> getDialogInstance(
     layoutId: Int,
     @StyleRes customStyle: Int? = null,
     setCancelable: Boolean = false,
-    crossinline onSuccess: (Dialog, V) -> Unit
-) {
+    crossinline onSuccess: (V) -> Unit
+): Dialog {
     val layout = DataBindingUtil.inflate<V>(LayoutInflater.from(activity), layoutId, null, false)
     val dialog = if (customStyle == null) Dialog(activity) else Dialog(activity, customStyle)
     dialog.setContentView(layout.root)
     dialog.window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     dialog.setCanceledOnTouchOutside(setCancelable)
     dialog.setCancelable(setCancelable)
-    onSuccess.invoke(dialog, layout)
+    onSuccess.invoke(layout)
+    return dialog
 }

--- a/NetworkX/src/main/res/layout/content_dialog_no_internet.xml
+++ b/NetworkX/src/main/res/layout/content_dialog_no_internet.xml
@@ -9,8 +9,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
 
         <androidx.cardview.widget.CardView
             android:layout_width="0dp"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![Release](https://jitpack.io/v/jitpack/android-example.svg)](https://jitpack.io/#rommansabbir/NetworkX)
 
-# NetworkX
-
-An easy & handy library to monitor device internet connection status.
+![NetworkX](https://user-images.githubusercontent.com/25950083/185731068-480fd969-f18d-439c-938a-6285a50c2be2.png)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,37 @@
-[![Release](https://jitpack.io/v/jitpack/android-example.svg)](https://jitpack.io/#rommansabbir/NetworkX)
-
 ![NetworkX](https://user-images.githubusercontent.com/25950083/185731068-480fd969-f18d-439c-938a-6285a50c2be2.png)
 
----
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
 
-## Documentation
+ <p align="center">
+    <a href="https://android-arsenal.com/details/1/8160"><img alt="Maintained" src="https://img.shields.io/badge/Android%20Arsenal-NetworkX-green.svg?style=flat" height="20"/></a>
+</p>
 
-### Installation
+ <p align="center">
+     <a href="https://github.com/rommansabbir/NetworkX"><img alt="Maintained" src="https://img.shields.io/badge/Maintained_Actively%3F-Yes-green.svg" height="20"/></a>
+</p>
 
-Step 1. Add the JitPack repository to your build file .
+ <p align="center">
+     <a href="https://jitpack.io/#rommansabbir/NetworkX"><img alt="JitPack" src="https://img.shields.io/badge/JitPack-Yes-green.svg?style=flat" height="20"/></a>
+</p>
+
+<h1 align="center"> ⚡ Latest Version: 4.1.0 | Change Logs 🔰</h1>
+
+- NetworkX now works with both __Activity__ or __Application__ Scope (NetworkX lifecycle is bounded to `NetworkXLifecycle.Activity` or `NetworkXLifecycle.Application`)
+- Introduced `SmartConfig` to replace old config [`NetworkXConfig` has been deprecated]
+- New __API__ to initialize `NetworkX`, enabled smart refactoring to replace old __API__ with new one
+- New __API__ [`NoInternetDialogV2.forceClose()`] added to close `Dialog` forcefully
+- Added support for custom _Drawable_ to be shown in `NoInternetDialogV2`
+- Several __Classes__, __APIs__ has been deprecated.
+- Removed unused classes/packages
+- Colorful Documentation 😂
+
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
+
+<h1 align="center">Installation</h1>
+
+## ➤ Step 1:
+
+Add the JitPack repository to your build file .
 
 ```gradle
     allprojects {
@@ -18,96 +41,105 @@ Step 1. Add the JitPack repository to your build file .
     }
 ```
 
-Step 2. Add the dependency.
+## ➤ Step 2:
+
+Add the dependency.
 
 ```gradle
     dependencies {
-            implementation 'com.github.rommansabbir:NetworkX:Tag'
+            implementation 'com.github.rommansabbir:NetworkX:4.1.0'
     }
 ```
 
----
-
-### Version available
-
-| Releases
-| ------------- |
-| 4.0.0         |
-
-
-# Usages
-
-## Step 1:
+## ➤ Step 3:
 Initialize `NetworkX` from your `Application.onCreate()`
 ````
+    //Deprecated way
     val builder = NetworkXConfig.Builder()
         .withApplication(this)
         // You can disable speed meter if not required
         .withEnableSpeedMeter(true)
         .build()
     NetworkXProvider.enable(builder)
+
+    //New smart way
+    NetworkXProvider.enable(SmartConfig(this, true, NetworkXLifecycle.Application))
 ````
 
-## Step 2:
+## ➤ Step 4:
 - To check Internet Connection status, simply call extension variable
 `isInternetConnected` or `isInternetConnectedLiveData` or `isInternetConnectedFlow`.
 ````
-isInternetConnectedFlow.collectLatest {
-    lifecycleScope.launch {
-            textView.text = "Internet connection status: $it"
+    isInternetConnectedFlow.collectLatest {
+        lifecycleScope.launch {
+                textView.text = "Internet connection status: $it"
+            }
         }
-    }
 ````
 
 - To get connected network speed/last known speed [`LastKnownSpeed`] call extension variable
 `lastKnownSpeed` or `lastKnownSpeedLiveData` or `lastKnownSpeedFlow`
 
 ````
-lastKnownSpeed?.let {
-    textView2.text ="S-${it.speed}|T-${it.networkTypeNetwork}|SS-${it.simplifiedSpeed}"
-}
+    lastKnownSpeed?.let {
+        textView2.text ="S-${it.speed}|T-${it.networkTypeNetwork}|SS-${it.simplifiedSpeed}"
+    }
 ````
 
- ## Notes:
- - **NetworkX** (including **Speed Meter**) only works when the **Activity** is in state between **OnCreate()**  to **onDestroy()**.
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
+
+
+<h1 align="center">NoInternetDialogV2</h1>
+
+- Show Dialog
+```kotlin
+    NoInternetDialogV2(
+        activity = WeakReference(this@MainActivity),
+        title = "No Internet Bro",
+        message = "This is just a dummy message",
+        buttonTitle = "Okay",
+        isCancelable = true
+    ) { /* Button Presses */ }
+```
+- Close Dialog (Forcefully)
+
+```kotlin
+    NoInternetDialogV2.forceClose()
+```
+- Determine if the `NoInternetDialogV2` is currently visible or not.
+
+```kotlin
+    NoInternetDialogV2.isVisible
+```
+
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
+
+
+<h1 align="center">Notes:</h1>
+
+ - **NetworkX** (including **Speed Meter**) can work on both **Application** scope or **Activity** scope. If scope is **Activity**, NetworkX will *start/release* it's components based on _ActivityLifecycleCallback_ (**onCreate - onDestroy**). Else, it will *start* it's components only once and there will be no components *release* event.
  - To emit (**`MutableStateFlow`**) **Last Known Speed** or **Internet Connection Status**,required **`CoroutineScope`** works under a **`Dispatchers.IO`** context.
  - The default value for **Internet Connection Status** is `false`.
  - The default value for **LastKnownSpeed** is `NONE`.
 
----
 
-### How to show the **`NoInternetDialogV2`**?
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
 
-```kotlin
-NoInternetDialogV2(
-    activity = WeakReference(this@MainActivity),
-    title = "No Internet Bro",
-    message = "This is just a dummy message",
-    buttonTitle = "Okay",
-    isCancelable = true
-) { /* Button Presses */ }
-```
+## Contact me
 
-* Also, you can determine if the `NoInternetDialogV2` is currently visible or not by calling this variable `NoInternetDialogV2.isVisible` which return an `Boolean`.
+✔ [LinkedIn](https://www.linkedin.com/in/rommansabbir/)
 
----
+✔ [Website](https://rommansabbir.com)
 
-### Happy Coding....
 
----
-
-### Contact me
-
-[LinkedIn](https://www.linkedin.com/in/rommansabbir/)
-
----
+[![-----------------------------------------------------](https://raw.githubusercontent.com/andreasbm/readme/master/assets/lines/colored.png)](#getting-started-quick)
 
 ### License
 
 [Apache Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 ````html
-Copyright (C) 2021 Romman Sabbir
+Copyright (C) 2022 Romman Sabbir
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:name=".DummyActivity"
+            android:exported="false" />
+        <activity
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/rommansabbir/networkobserverexample/DummyActivity.kt
+++ b/app/src/main/java/com/rommansabbir/networkobserverexample/DummyActivity.kt
@@ -1,0 +1,50 @@
+package com.rommansabbir.networkobserverexample
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.rommansabbir.networkx.NetworkXProvider
+import com.rommansabbir.networkx.dialog.NoInternetDialogV2
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+
+class DummyActivity : AppCompatActivity() {
+    @SuppressLint("SetTextI18n")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_dummy)
+
+        lifecycleScope.launchWhenCreated {
+            try {
+                NetworkXProvider.isInternetConnectedFlow.collect {
+                    lifecycleScope.launch {
+                        if (!it) {
+                            if (!NoInternetDialogV2.isVisible) {
+                                NoInternetDialogV2(
+                                    activity = WeakReference(this@DummyActivity),
+                                    title = "No Internet Bro",
+                                    message = "This is just a dummy message",
+                                    buttonTitle = "Okay",
+                                    isCancelable = false
+                                ) {
+                                }
+                            }
+                        } else {
+                            NoInternetDialogV2.forceClose()
+                            Toast.makeText(
+                                this@DummyActivity,
+                                "Is connected? : $it",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rommansabbir/networkobserverexample/MainActivity.kt
+++ b/app/src/main/java/com/rommansabbir/networkobserverexample/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.rommansabbir.networkobserverexample
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -10,7 +11,6 @@ import com.rommansabbir.networkx.NetworkXProvider.isInternetConnectedFlow
 import com.rommansabbir.networkx.NetworkXProvider.lastKnownSpeedFlow
 import com.rommansabbir.networkx.dialog.NoInternetDialogV2
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
@@ -27,7 +27,17 @@ class MainActivity : AppCompatActivity() {
         //
         NetworkXProvider.isInternetConnectedLiveData.observe(this) {
             it?.let {
-                textView.text = "Internet connection status: $it"
+                NoInternetDialogV2.forceClose()
+                if (!it) {
+                    NoInternetDialogV2(
+                        activity = WeakReference(this@MainActivity),
+                        title = "No Internet Bro",
+                        message = "This is just a dummy message",
+                        buttonTitle = "Okay",
+                        isCancelable = false
+                    ) {
+                    }
+                }
             }
         }
 
@@ -53,23 +63,6 @@ class MainActivity : AppCompatActivity() {
                 isInternetConnectedFlow.collect {
                     lifecycleScope.launch {
                         textView.text = "Internet connection status: $it"
-                        if (!it){
-                            if (!NoInternetDialogV2.isVisible) {
-                                NoInternetDialogV2(
-                                    activity = WeakReference(this@MainActivity),
-                                    title = "No Internet Bro",
-                                    message = "This is just a dummy message",
-                                    buttonTitle = "Okay",
-                                    isCancelable = false
-                                ) {
-                                    Toast.makeText(
-                                        this@MainActivity,
-                                        "Is dialog cancelled? : ${!NoInternetDialogV2.isVisible}",
-                                        Toast.LENGTH_SHORT
-                                    ).show()
-                                }
-                            }
-                        }
                     }
                 }
             } catch (e: Exception) {
@@ -77,5 +70,10 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        button.setOnClickListener {
+            NoInternetDialogV2.forceClose()
+            startActivity(Intent(this@MainActivity, DummyActivity::class.java))
+        }
     }
+
 }

--- a/app/src/main/java/com/rommansabbir/networkobserverexample/MainActivity.kt
+++ b/app/src/main/java/com/rommansabbir/networkobserverexample/MainActivity.kt
@@ -53,6 +53,23 @@ class MainActivity : AppCompatActivity() {
                 isInternetConnectedFlow.collect {
                     lifecycleScope.launch {
                         textView.text = "Internet connection status: $it"
+                        if (!it){
+                            if (!NoInternetDialogV2.isVisible) {
+                                NoInternetDialogV2(
+                                    activity = WeakReference(this@MainActivity),
+                                    title = "No Internet Bro",
+                                    message = "This is just a dummy message",
+                                    buttonTitle = "Okay",
+                                    isCancelable = false
+                                ) {
+                                    Toast.makeText(
+                                        this@MainActivity,
+                                        "Is dialog cancelled? : ${!NoInternetDialogV2.isVisible}",
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                        }
                     }
                 }
             } catch (e: Exception) {
@@ -60,23 +77,5 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        lifecycleScope.launch {
-            delay(5000)
-            if (!NoInternetDialogV2.isVisible) {
-                NoInternetDialogV2(
-                    activity = WeakReference(this@MainActivity),
-                    title = "No Internet Bro",
-                    message = "This is just a dummy message",
-                    buttonTitle = "Okay",
-                    isCancelable = true
-                ) {
-                    Toast.makeText(
-                        this@MainActivity,
-                        "Is dialog cancelled? : ${!NoInternetDialogV2.isVisible}",
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/com/rommansabbir/networkobserverexample/MyApplication.kt
+++ b/app/src/main/java/com/rommansabbir/networkobserverexample/MyApplication.kt
@@ -1,20 +1,25 @@
 package com.rommansabbir.networkobserverexample
 
 import android.app.Application
-import com.rommansabbir.networkx.NetworkXConfig
+import com.rommansabbir.networkx.NetworkXLifecycle
 import com.rommansabbir.networkx.NetworkXProvider
+import com.rommansabbir.networkx.SmartConfig
 
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        /**
-         * Initialize NetworkX
-         */
-        val builder = NetworkXConfig
+        /*Deprecated way*/
+        /*val builder = NetworkXConfig
             .Builder()
             .withApplication(this)
             .withEnableSpeedMeter(true)
             .build()
-        NetworkXProvider.enable(builder)
+        NetworkXProvider.enable(builder)*/
+
+        /*New way*/
+        NetworkXProvider.enable(SmartConfig(this, true, NetworkXLifecycle.Application))
+
+        /*Smart extension*/
+        /*smartEnableNetworkX(SmartConfig(this, true, NetworkXLifecycle.Application))*/
     }
 }

--- a/app/src/main/res/layout/activity_dummy.xml
+++ b/app/src/main/res/layout/activity_dummy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".DummyActivity">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,5 +35,16 @@
             app:layout_constraintEnd_toEndOf="@+id/textView"
             app:layout_constraintStart_toStartOf="@+id/textView"
             app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+        <Button
+            android:id="@+id/button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="32dp"
+            android:text="Start Dummy Activity"
+            android:textAllCaps="false"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
Change Logs 🔰
- NetworkX now works with both __Activity__ or __Application__ Scope (NetworkX lifecycle is bounded to `NetworkXLifecycle.Activity` or `NetworkXLifecycle.Application`)
- Introduced `SmartConfig` to replace old config [`NetworkXConfig` has been deprecated]
- New __API__ to initialize `NetworkX`, enabled smart refactoring to replace old __API__ with new one
- New __API__ [`NoInternetDialogV2.forceClose()`] added to close `Dialog` forcefully
- Added support for custom _Drawable_ to be shown in `NoInternetDialogV2`
- Several __Classes__, __APIs__ has been deprecated.
- Removed unused classes/packages
- Colorful Documentation 😂